### PR TITLE
Fixing division by pointer bug

### DIFF
--- a/devito/ops/node_factory.py
+++ b/devito/ops/node_factory.py
@@ -49,6 +49,7 @@ class OPSNodeFactory(object):
 
             accessible_info = AccessibleInfo(
                 symbol_to_access,
+                None,
                 time_index.var if indexed.function.is_TimeFunction else None,
                 indexed.function.name)
 
@@ -69,13 +70,26 @@ class OPSNodeFactory(object):
         return OpsAccess(symbol_to_access, space_indices)
 
     def new_ops_gbl(self, c):
+        """
+        Defines Constant Symbols to have an '*' making them pointers, as needed by ops.
+
+        Parameters
+        ----------
+        c : Constant
+            Constant symbol.
+
+        Returns
+        -------
+        Constant
+            Constant Symbol, as a pointer.
+        """
         if c in self.ops_args:
-            return self.ops_args[c].accessible
+            return self.ops_args[c].safe_accessible
 
         new_c = AccessibleInfo(Constant(name='*%s' % c.name, dtype=c.dtype),
+                               Constant(name='(*%s)' % c.name, dtype=c.dtype),
                                None,
                                None)
         self.ops_args[c] = new_c
         self.ops_params.append(new_c.accessible)
-
-        return new_c.accessible
+        return new_c.safe_accessible

--- a/devito/ops/utils.py
+++ b/devito/ops/utils.py
@@ -9,7 +9,7 @@ from devito.symbolics import Macro
 namespace = OrderedDict()
 AccessibleInfo = namedtuple(
     'AccessibleInfo',
-    ['accessible', 'time', 'origin_name'])
+    ['accessible', 'safe_accessible', 'time', 'origin_name'])
 
 OpsDatDecl = namedtuple(
     'OpsDatDecl',

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -29,13 +29,13 @@ class TestOPSExpression(object):
          '{\n  ut0(0) = -2.97015324253729F;\n}'),
         ('Eq(u, u.dxl)',
          'void OPS_Kernel_0(ACC<float> & ut0, const float *h_x)\n'
-         '{\n  float r0 = 1.0/*h_x;\n  '
+         '{\n  float r0 = 1.0/(*h_x);\n  '
          'ut0(0) = (-2.0F*ut0(-1) + 5.0e-1F*ut0(-2) + 1.5F*ut0(0))*r0;\n}'),
         ('Eq(v,1)', 'void OPS_Kernel_0(ACC<float> & vt0)\n'
          '{\n  vt0(0, 0) = 1;\n}'),
         ('Eq(v,v.dxl + v.dxr - v.dyr - v.dyl)',
          'void OPS_Kernel_0(ACC<float> & vt0, const float *h_x, const float *h_y)\n'
-         '{\n  float r1 = 1.0/*h_y;\n  float r0 = 1.0/*h_x;\n  '
+         '{\n  float r1 = 1.0/(*h_y);\n  float r0 = 1.0/(*h_x);\n  '
          'vt0(0, 0) = (5.0e-1F*(-vt0(2, 0) + vt0(-2, 0)) + 2.0F*(-vt0(-1, 0) + '
          'vt0(1, 0)))*r0 + (5.0e-1F*(-vt0(0, -2) + vt0(0, 2)) + '
          '2.0F*(-vt0(0, 1) + vt0(0, -1)))*r1;\n}'),
@@ -54,9 +54,9 @@ class TestOPSExpression(object):
         ('Eq(v.forward, v.dt - v.laplace + v.dt)',
          'void OPS_Kernel_0(const ACC<float> & vt0, ACC<float> & vt1, '
          'const float *dt, const float *h_x, const float *h_y)\n'
-         '{\n  float r2 = 1.0/*dt;\n'
-         '  float r1 = 1.0/(*h_y**h_y);\n'
-         '  float r0 = 1.0/(*h_x**h_x);\n'
+         '{\n  float r2 = 1.0/(*dt);\n'
+         '  float r1 = 1.0/((*h_y)*(*h_y));\n'
+         '  float r0 = 1.0/((*h_x)*(*h_x));\n'
          '  vt1(0, 0) = (-(vt0(1, 0) + vt0(-1, 0)) + 2.0F*vt0(0, 0))*r0 + '
          '(-(vt0(0, 1) + vt0(0, -1)) + 2.0F*vt0(0, 0))*r1 + '
          '2*(-vt0(0, 0) + vt1(0, 0))*r2;\n}'),
@@ -223,7 +223,7 @@ class TestOPSExpression(object):
         u = OpsAccessible('u', dtype=np.float32, read_only=read)
         dat = OpsDat('u_dat')
         stencil = OpsStencil('stencil')
-        info = AccessibleInfo(u, None, None)
+        info = AccessibleInfo(u, None, None, None)
 
         ops_arg = create_ops_arg(u, {'u': info}, {'u': dat}, {u: stencil})
 


### PR DESCRIPTION
When translating to OPS a division by pointer (/*) would make the
rest of the code a commentary in c++. This was solved by encasing
the pointer by parenthesis.